### PR TITLE
Add exile functionality

### DIFF
--- a/db/migrations/20250315131047_add_exiled_to_user.sql
+++ b/db/migrations/20250315131047_add_exiled_to_user.sql
@@ -1,0 +1,4 @@
+-- migrate:up
+ALTER TABLE farmer ADD COLUMN exiled BOOLEAN NOT NULL DEFAULT FALSE;
+INSERT INTO balance (farmer, commodity, amount) VALUES ('JAIL', 1, 0);
+-- migrate:down

--- a/env.d.ts
+++ b/env.d.ts
@@ -3,5 +3,6 @@ declare module "bun" {
     DISCORD_TOKEN: string;
     DISCORD_APPLICATION_ID: string;
     DATABASE_PATH: string;
+    CORN_CZAR_ID: string;
   }
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -58,8 +58,8 @@ export const commands: Array<Command> = [
           case "ALREADY_DOLED":
             await interaction.reply(
               `You have already harvested today. You can harvest again in ${formatDuration(
-                doleResult.error.duration
-              )}.`
+                doleResult.error.duration,
+              )}.`,
             );
             break;
           default:
@@ -139,13 +139,13 @@ export const commands: Array<Command> = [
         option
           .setName("user")
           .setDescription("The user to send corn to")
-          .setRequired(true)
+          .setRequired(true),
       )
       .addIntegerOption((option) =>
         option
           .setName("amount")
           .setDescription("The amount of corn to send")
-          .setRequired(true)
+          .setRequired(true),
       ) as SlashCommandBuilder,
     handler: async (interaction) => {
       if (isExiled(interaction.user.id)) {
@@ -162,7 +162,7 @@ export const commands: Array<Command> = [
         amount,
         destinationUser.id,
         Commodity.Corn,
-        amount
+        amount,
       );
       if ("error" in tradeResult) {
         switch (tradeResult.error) {
@@ -183,7 +183,7 @@ export const commands: Array<Command> = [
           new EmbedBuilder()
             .setTitle("Transfer successful")
             .setDescription(
-              `You have sent ${amount} cobs of corn to <@${destinationUser.id}>.`
+              `You have sent ${amount} cobs of corn to <@${destinationUser.id}>.`,
             )
             .addFields([
               {
@@ -219,7 +219,7 @@ export const commands: Array<Command> = [
               return `${balances.indexOf(entry.amount) + 1}\\. ${
                 user.username
               }: ${entry.amount}`;
-            })
+            }),
         )
       ).join("\n");
       await interaction.reply(`The top corn barons are:\n${leaderboard}`);
@@ -233,7 +233,7 @@ export const commands: Array<Command> = [
         option
           .setName("user")
           .setDescription("The user to exile")
-          .setRequired(true)
+          .setRequired(true),
       ) as SlashCommandBuilder,
     handler: async (interaction) => {
       const user = interaction.options.getUser("user")!;
@@ -256,7 +256,7 @@ export const commands: Array<Command> = [
           new EmbedBuilder()
             .setTitle(`${user.username} has been exiled.`)
             .setDescription(
-              `All ${exileResult.value.jailed} cobs of corn have been sent to jail.`
+              `All ${exileResult.value.jailed} cobs of corn have been sent to jail.`,
             ),
         ],
       });

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -55,7 +55,7 @@ export const trade = (
   sourceAmount: number,
   destinationFarmer: string,
   destinationCommodity: Commodity,
-  destinationAmount: number
+  destinationAmount: number,
 ): TransferResult => {
   if (sourceAmount <= 0) {
     return { error: "INVALID_AMOUNT" };
@@ -120,7 +120,7 @@ export const dole = (id: string): DoleResult => {
     DOLE_RESULT[result],
     id,
     Commodity.Corn,
-    DOLE_RESULT[result]
+    DOLE_RESULT[result],
   );
   if ("error" in transferResult) {
     return { error: { type: "UNKNOWN_ERROR" } };
@@ -168,7 +168,7 @@ export const exile = (id: string): ExileResult => {
       amountToBeExiled,
       "JAIL",
       Commodity.Corn,
-      amountToBeExiled
+      amountToBeExiled,
     );
 
     if ("error" in exileResult) {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -4,15 +4,17 @@ import {
   intervalToDuration,
   type Duration,
 } from "date-fns";
+import { Commodity } from "./enum";
 import {
+  CREATE_TRADE,
+  ENSURE_FARMER,
+  EXILE,
+  GET_BALANCE,
   GET_BALANCES,
   GET_LAST_DOLED,
-  CREATE_TRADE,
+  IS_EXILED,
   TOP_BALANCES,
-  ENSURE_FARMER,
-  GET_BALANCE,
 } from "./statements";
-import { Commodity } from "./enum";
 
 type Result<T, E> = { value: T } | { error: E };
 
@@ -28,6 +30,13 @@ type DoleResult = Result<
   { result: keyof typeof DOLE_RESULT; yield: number; balance: number },
   { type: "ALREADY_DOLED"; duration: Duration } | { type: "UNKNOWN_ERROR" }
 >;
+
+type ExileResult = Result<
+  { result: "EXILED"; jailed: number },
+  { type: "ALREADY_EXILED" } | { type: "UNKNOWN_ERROR" }
+>;
+
+type IsExiledResult = Result<boolean, { type: "UNKNOWN_ERROR" }>;
 
 const DOLE_RESULT = {
   NORMAL: 100,
@@ -46,7 +55,7 @@ export const trade = (
   sourceAmount: number,
   destinationFarmer: string,
   destinationCommodity: Commodity,
-  destinationAmount: number,
+  destinationAmount: number
 ): TransferResult => {
   if (sourceAmount <= 0) {
     return { error: "INVALID_AMOUNT" };
@@ -111,7 +120,7 @@ export const dole = (id: string): DoleResult => {
     DOLE_RESULT[result],
     id,
     Commodity.Corn,
-    DOLE_RESULT[result],
+    DOLE_RESULT[result]
   );
   if ("error" in transferResult) {
     return { error: { type: "UNKNOWN_ERROR" } };
@@ -128,4 +137,49 @@ export const dole = (id: string): DoleResult => {
 
 export const getTopBalances = () => {
   return TOP_BALANCES.all();
+};
+
+export const isExiled = (id: string): boolean => {
+  const isExiled = IS_EXILED.get(id);
+  return isExiled?.exiled ?? false;
+};
+
+export const exile = (id: string): ExileResult => {
+  ENSURE_FARMER.run(id);
+
+  const isExiled = IS_EXILED.get(id)?.exiled;
+
+  if (isExiled) {
+    return { error: { type: "ALREADY_EXILED" } };
+  }
+
+  EXILE.run(id);
+
+  const amountToBeExiled =
+    GET_BALANCE.get({
+      $farmer: id,
+      $commodity: Commodity.Corn,
+    })?.amount ?? 0;
+
+  if (amountToBeExiled > 0) {
+    const exileResult = trade(
+      id,
+      Commodity.Corn,
+      amountToBeExiled,
+      "JAIL",
+      Commodity.Corn,
+      amountToBeExiled
+    );
+
+    if ("error" in exileResult) {
+      return { error: { type: "UNKNOWN_ERROR" } };
+    }
+  }
+
+  return {
+    value: {
+      result: "EXILED",
+      jailed: amountToBeExiled,
+    },
+  };
 };

--- a/src/statements.ts
+++ b/src/statements.ts
@@ -5,7 +5,7 @@ export const GET_BALANCE = db.prepare<
   { amount: number },
   [{ $farmer: string; $commodity: Commodity }]
 >(
-  `SELECT amount FROM balance WHERE farmer = $farmer AND commodity = $commodity`
+  `SELECT amount FROM balance WHERE farmer = $farmer AND commodity = $commodity`,
 );
 
 export const GET_BALANCES = db.prepare<
@@ -43,11 +43,11 @@ export const CREATE_TRADE = db.prepare<
 `);
 
 export const ENSURE_FARMER = db.prepare<undefined, [string]>(
-  "INSERT OR IGNORE INTO farmer (id, date_started) VALUES (?, CURRENT_TIMESTAMP)"
+  "INSERT OR IGNORE INTO farmer (id, date_started) VALUES (?, CURRENT_TIMESTAMP)",
 );
 
 export const GET_LAST_DOLED = db.prepare<{ date: string }, [string]>(
-  "SELECT date FROM trade WHERE source_farmer = 'BANK' AND destination_farmer = ? ORDER BY date DESC LIMIT 1"
+  "SELECT date FROM trade WHERE source_farmer = 'BANK' AND destination_farmer = ? ORDER BY date DESC LIMIT 1",
 );
 
 export const TOP_BALANCES = db.prepare<{ farmer: string; amount: number }, []>(`

--- a/src/statements.ts
+++ b/src/statements.ts
@@ -5,7 +5,7 @@ export const GET_BALANCE = db.prepare<
   { amount: number },
   [{ $farmer: string; $commodity: Commodity }]
 >(
-  `SELECT amount FROM balance WHERE farmer = $farmer AND commodity = $commodity`,
+  `SELECT amount FROM balance WHERE farmer = $farmer AND commodity = $commodity`
 );
 
 export const GET_BALANCES = db.prepare<
@@ -43,11 +43,11 @@ export const CREATE_TRADE = db.prepare<
 `);
 
 export const ENSURE_FARMER = db.prepare<undefined, [string]>(
-  "INSERT OR IGNORE INTO farmer (id, date_started) VALUES (?, CURRENT_TIMESTAMP)",
+  "INSERT OR IGNORE INTO farmer (id, date_started) VALUES (?, CURRENT_TIMESTAMP)"
 );
 
 export const GET_LAST_DOLED = db.prepare<{ date: string }, [string]>(
-  "SELECT date FROM trade WHERE source_farmer = 'BANK' AND destination_farmer = ? ORDER BY date DESC LIMIT 1",
+  "SELECT date FROM trade WHERE source_farmer = 'BANK' AND destination_farmer = ? ORDER BY date DESC LIMIT 1"
 );
 
 export const TOP_BALANCES = db.prepare<{ farmer: string; amount: number }, []>(`
@@ -55,4 +55,12 @@ export const TOP_BALANCES = db.prepare<{ farmer: string; amount: number }, []>(`
   FROM balance
   WHERE commodity = 1
   ORDER BY amount DESC LIMIT 10
+`);
+
+export const EXILE = db.prepare<undefined, [string]>(`
+  UPDATE farmer SET exiled = 1 WHERE id = ?
+`);
+
+export const IS_EXILED = db.prepare<{ exiled: boolean }, [string]>(`
+  SELECT exiled FROM farmer WHERE id = ? LIMIT 1
 `);


### PR DESCRIPTION
New Features:
- Exile Functionality
  - A user can be exiled, which will prevent them from interacting with the Corn Bot, and all of their corn will be sent to a `jail` account.
  - Exile functionality can only be used by the User ID that is set in the `CORN_CZAR_ID` environment variable.
